### PR TITLE
Refactor post handling to support polls and quizzes

### DIFF
--- a/lib/feature/home/presentation/screens/home_screen.dart
+++ b/lib/feature/home/presentation/screens/home_screen.dart
@@ -3,8 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:prone/core/routes/app_router.dart';
 import 'package:prone/feature/auth/presentation/cubits/auth_cubit.dart';
-import 'package:prone/feature/home/widgets/post_cards/post_card.dart';
-import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/home/widgets/post_cards/poll_card.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
+
 import 'package:prone/l10n/app_localizations.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -33,9 +34,9 @@ class HomeScreen extends StatelessWidget {
       body: Center(
         child: ListView(
           children: [
-            PostCard(post: PostModel.mockPost),
-            PostCard(post: PostModel.mockPost2),
-            PostCard(post: PostModel.mockPost3),
+            PollCard(poll: PollModel.mockData()),
+            PollCard(poll: PollModel.mockData()),
+            PollCard(poll: PollModel.mockData()),
           ],
         ),
       ),

--- a/lib/feature/home/widgets/post_cards/components/poll_option.dart
+++ b/lib/feature/home/widgets/post_cards/components/poll_option.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:prone/core/extensions/color_extension.dart';
-import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/post/domain/models/option_model.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
 
 class PollOption extends StatelessWidget {
   final OptionModel option;
-  final PostModel post;
+  final PollModel poll;
 
-  const PollOption({super.key, required this.option, required this.post});
+  const PollOption({super.key, required this.option, required this.poll});
 
   @override
   Widget build(BuildContext context) {
-    if (post.userVoted) {
+    if (poll.userVoted) {
       return _buildResultOption(context);
     } else {
       return _buildVoteOption(context);
@@ -18,7 +19,7 @@ class PollOption extends StatelessWidget {
   }
 
   Widget _buildResultOption(BuildContext context) {
-    final bool isSelectedOption = post.userVoteOption == option.id;
+    final bool isSelectedOption = poll.userVoteOption == option.id;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 5.0),

--- a/lib/feature/home/widgets/post_cards/components/poll_section.dart
+++ b/lib/feature/home/widgets/post_cards/components/poll_section.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
+
 import 'poll_option.dart';
 
 class PollSection extends StatelessWidget {
-  final PostModel post;
+  final PollModel poll;
 
-  const PollSection({super.key, required this.post});
+  const PollSection({super.key, required this.poll});
 
   @override
   Widget build(BuildContext context) {
     return Column(
-      children: post.options.map((option) {
-        return PollOption(option: option, post: post);
+      children: poll.options.map((option) {
+        return PollOption(option: option, poll: poll);
       }).toList(),
     );
   }

--- a/lib/feature/home/widgets/post_cards/components/post_footer.dart
+++ b/lib/feature/home/widgets/post_cards/components/post_footer.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
 import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/post/domain/models/quiz_model.dart';
 
 class PostFooter extends StatelessWidget {
   final PostModel post;
@@ -12,12 +14,27 @@ class PostFooter extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         Text(
-          'Toplam Oy: ${post.totalVotes}',
+          _getFooterText(),
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),
         ),
       ],
     );
+  }
+
+  String _getFooterText() {
+    switch (post.type) {
+      case PostType.poll:
+        final pollPost = post as PollModel;
+        return 'Toplam Oy: ${pollPost.totalVotes}';
+
+      case PostType.quiz:
+        final quizPost = post as QuizModel;
+        return 'Katılımcı: ${quizPost.totalParticipants}';
+
+      default:
+        return '';
+    }
   }
 }

--- a/lib/feature/home/widgets/post_cards/poll_card.dart
+++ b/lib/feature/home/widgets/post_cards/poll_card.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
+
 import 'components/post_header.dart';
 import 'components/post_content.dart';
 import 'components/post_footer.dart';
 import 'components/poll_section.dart';
 
-class PostCard extends StatelessWidget {
-  final PostModel post;
+class PollCard extends StatelessWidget {
+  final PollModel poll; // ✅ PollModel al
 
-  const PostCard({super.key, required this.post});
+  const PollCard({super.key, required this.poll});
 
   @override
   Widget build(BuildContext context) {
@@ -22,15 +23,18 @@ class PostCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            PostHeader(post: post),
+            PostHeader(post: poll), // ✅ poll polymorphic olarak geçer
             const SizedBox(height: 16),
 
-            PostContent(post: post),
+            PostContent(post: poll), // ✅ poll polymorphic olarak geçer
             const SizedBox(height: 16),
-            if (post.type == PostType.poll) PollSection(post: post),
+
+            // ✅ Direkt PollSection kullan
+            PollSection(poll: poll),
+
             const SizedBox(height: 12),
 
-            PostFooter(post: post),
+            PostFooter(post: poll), // ✅ poll polymorphic olarak geçer
           ],
         ),
       ),

--- a/lib/feature/post/data/supabase_post_repo.dart
+++ b/lib/feature/post/data/supabase_post_repo.dart
@@ -2,7 +2,8 @@ import 'dart:developer';
 
 import 'package:prone/core/constants/supabase_constants.dart';
 import 'package:prone/feature/post/domain/models/create_poll_model.dart';
-import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
+
 import 'package:prone/feature/post/domain/repos/post_repo.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -10,7 +11,7 @@ class SupabasePostRepo extends PostRepo {
   final _supabase = Supabase.instance.client;
 
   @override
-  Future<PostModel> createPoll({required CreatePollModel post}) async {
+  Future<PollModel> createPoll({required CreatePollModel post}) async {
     try {
       final user = _getCurrentUser();
       post = post.copyWith(userId: user?.id);
@@ -40,31 +41,7 @@ class SupabasePostRepo extends PostRepo {
           .select();
 
       inspect(optionResponse);
-
-      // return PostModel(
-      //   id: createdPost.id,
-      //   userId: createdPost.userId,
-      //   title: createdPost.title,
-      //   body: createdPost.body,
-      //   type: createdPost.type,
-      //   createdAt: createdPost.createdAt,
-      //   totalVotes: createdPost.totalVotes,
-      //   userVoted: createdPost.userVoted,
-      //   userVoteOption: createdPost.userVoteOption,
-      //   // options: optionResponse
-      //   //     .map((option) => OptionModel.fromJson(option))
-      //   //     .toList(),
-      //   options: [],
-      // );
-      return PostModel(
-        title: "title",
-        userId: "userId",
-        createdAt: DateTime.now(),
-        totalVotes: 0,
-        options: [],
-        userVoted: false,
-        userVoteOption: "userVoteOption",
-      );
+      return PollModel.fromJson(postResponse);
     } catch (e) {
       inspect(e);
       throw Exception('Post creation failed: $e');

--- a/lib/feature/post/domain/models/option_model.dart
+++ b/lib/feature/post/domain/models/option_model.dart
@@ -1,0 +1,56 @@
+import 'package:prone/feature/post/domain/models/create_poll_model.dart';
+
+class OptionModel {
+  final String id;
+  final String text;
+  final int votes;
+  final double percentage;
+
+  OptionModel({
+    required this.id,
+    required this.text,
+    required this.votes,
+    required this.percentage,
+  });
+
+  factory OptionModel.fromJson(Map<String, dynamic> json) {
+    return OptionModel(
+      id: json['id'] as String,
+      text: json['text'] as String,
+      votes: json['votes'] as int? ?? 0,
+      percentage: (json['percentage'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  factory OptionModel.fromCreateOptionModel({
+    required CreateOptionModel option,
+    required String optionId,
+  }) {
+    return OptionModel(
+      id: optionId,
+      text: option.text,
+      votes: 0,
+      percentage: 0.0,
+    );
+  }
+
+  // ✅ Eksik olan toJson() metodu
+  Map<String, dynamic> toJson() {
+    return {'id': id, 'text': text, 'votes': votes, 'percentage': percentage};
+  }
+
+  // ✅ Bonus: copyWith metodu da ekleyelim
+  OptionModel copyWith({
+    String? id,
+    String? text,
+    int? votes,
+    double? percentage,
+  }) {
+    return OptionModel(
+      id: id ?? this.id,
+      text: text ?? this.text,
+      votes: votes ?? this.votes,
+      percentage: percentage ?? this.percentage,
+    );
+  }
+}

--- a/lib/feature/post/domain/models/poll_model.dart
+++ b/lib/feature/post/domain/models/poll_model.dart
@@ -1,0 +1,93 @@
+import 'package:prone/feature/post/domain/models/option_model.dart';
+import 'package:prone/feature/post/domain/models/post_model.dart';
+
+class PollModel extends PostModel {
+  final int totalVotes;
+  final List<OptionModel> options;
+  final bool userVoted;
+  final String userVoteOption;
+
+  const PollModel({
+    super.id,
+    required super.title,
+    super.body,
+    super.imageUrls,
+    required super.userId,
+    required super.createdAt,
+    super.status,
+    required this.totalVotes,
+    required this.options,
+    required this.userVoted,
+    required this.userVoteOption,
+  }) : super(type: PostType.poll);
+
+  factory PollModel.fromJson(Map<String, dynamic> json) {
+    return PollModel(
+      id: json['id'] as String?,
+      title: json['title'] as String,
+      body: json['body'] as String?,
+      imageUrls: json['image_urls'] != null
+          ? List<String>.from(json['image_urls'] as List)
+          : null,
+      userId: json['user_id'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      status: PostStatus.values.firstWhere(
+        (e) => e.name == (json['status'] as String? ?? 'draft'),
+        orElse: () => PostStatus.draft,
+      ),
+      totalVotes: json['total_votes'] as int? ?? 0,
+      options: (json['options'] as List<dynamic>)
+          .map((option) => OptionModel.fromJson(option as Map<String, dynamic>))
+          .toList(),
+      userVoted: json['user_voted'] as bool? ?? false,
+      userVoteOption: json['user_vote_option'] as String? ?? '',
+    );
+  }
+
+  @override
+  Map<String, dynamic> toBaseJson() {
+    return {
+      'id': id,
+      'title': title,
+      'body': body,
+      'image_urls': imageUrls,
+      'user_id': userId,
+      'created_at': createdAt.toIso8601String(),
+      'post_type': type.name,
+      'status': status.name,
+      'total_votes': totalVotes,
+      'options': options.map((option) => option.toJson()).toList(),
+      'user_voted': userVoted,
+      'user_vote_option': userVoteOption,
+    };
+  }
+
+  static PollModel mockData({
+    String? id,
+    String? title,
+    String? body,
+    List<String>? imageUrls,
+    String? userId,
+    DateTime? createdAt,
+    PostStatus status = PostStatus.draft,
+  }) {
+    return PollModel(
+      id: id ?? 'poll_${DateTime.now().millisecondsSinceEpoch}',
+      title: title ?? 'Sample Poll',
+      body: body ?? 'This is a sample poll description.',
+      imageUrls:
+          imageUrls ??
+          ['https://1000logos.net/wp-content/uploads/2016/10/Apple-Logo.png'],
+      userId: userId ?? 'user_123',
+      createdAt: createdAt ?? DateTime.now(),
+      status: status,
+      totalVotes: 5,
+      options: [
+        OptionModel(id: 'option_1', text: 'Option 1', votes: 3, percentage: 60),
+        OptionModel(id: 'option_2', text: 'Option 2', votes: 2, percentage: 40),
+      ],
+      userVoted: true,
+      userVoteOption: 'option_1',
+    );
+  }
+}

--- a/lib/feature/post/domain/models/post_model.dart
+++ b/lib/feature/post/domain/models/post_model.dart
@@ -1,151 +1,44 @@
-import 'package:prone/feature/post/domain/models/create_poll_model.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
+import 'package:prone/feature/post/domain/models/quiz_model.dart';
 
 enum PostType { poll, quiz }
 
 enum PostStatus { draft, published, archived, deleted }
 
-class OptionModel {
-  final String id;
-  final String text;
-  final int votes;
-  final double percentage;
-
-  OptionModel({
-    required this.id,
-    required this.text,
-    required this.votes,
-    required this.percentage,
-  });
-
-  factory OptionModel.fromJson(Map<String, dynamic> json) {
-    return OptionModel(
-      id: json['id'] as String,
-      text: json['text'] as String,
-      votes: json['votes'] as int? ?? 0,
-      percentage: (json['percentage'] as num?)?.toDouble() ?? 0.0,
-    );
-  }
-
-  factory OptionModel.fromCreateOptionModel({
-    required CreateOptionModel option,
-    required String optionId,
-  }) {
-    return OptionModel(
-      id: optionId,
-      text: option.text,
-      votes: 0,
-      percentage: 0.0,
-    );
-  }
-}
-
-class PostModel {
+abstract class PostModel {
   final String? id;
   final String title;
   final String? body;
   final List<String>? imageUrls;
   final String userId;
   final DateTime createdAt;
-  final int totalVotes;
-  final List<OptionModel> options;
-  final bool userVoted;
-  final String userVoteOption;
   final PostType type;
+  final PostStatus status;
 
-  PostModel({
+  const PostModel({
     this.id,
     required this.title,
     this.body,
     this.imageUrls,
     required this.userId,
     required this.createdAt,
-    required this.totalVotes,
-    required this.options,
-    required this.userVoted,
-    required this.userVoteOption,
-    this.type = PostType.poll,
+    required this.type,
+    this.status = PostStatus.draft,
   });
 
-  factory PostModel.fromJson(Map<String, dynamic> json) {
-    return PostModel(
-      id: json['id'] as String,
-      userId: json['user_id'] as String,
-      type: PostType.values.firstWhere(
-        (e) => e.name == (json['post_type'] as String? ?? 'poll'),
-        orElse: () => PostType.poll,
-      ),
-      title: json['title'] as String,
-      body: json['body'] as String?,
-      imageUrls: json['image_urls'] != null
-          ? List<String>.from(json['image_urls'] as List)
-          : null,
-      createdAt: DateTime.parse(json['created_at'] as String),
-      totalVotes: json['total_votes'] as int? ?? 0,
-      options: (json['options'] as List<dynamic>).map((option) {
-        return OptionModel.fromJson(option as Map<String, dynamic>);
-      }).toList(),
-      userVoted: json['user_voted'] as bool? ?? false,
-      userVoteOption: json['user_vote_option'] as String? ?? '',
+  // Common methods
+  Map<String, dynamic> toBaseJson();
+  static PostModel fromJson(Map<String, dynamic> json) {
+    final type = PostType.values.firstWhere(
+      (e) => e.name == (json['post_type'] as String? ?? 'poll'),
+      orElse: () => PostType.poll,
     );
+
+    switch (type) {
+      case PostType.poll:
+        return PollModel.fromJson(json);
+      case PostType.quiz:
+        return QuizModel.fromJson(json);
+    }
   }
-
-  ///////////////MOCK DATA FOR TESTING/////////////
-  static PostModel mockPost = PostModel(
-    id: '1',
-    title: 'Hangi programlama dili daha popüler?',
-    body:
-        'Günümüzde yazılım geliştirme dünyasında hangi programlama dilinin daha popüler olduğunu merak ediyorum. Sizce hangisi?',
-    imageUrls: [
-      'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=800&h=400&fit=crop',
-      'https://images.unsplash.com/photo-1555949963-aa79dcee981c?w=800&h=400&fit=crop',
-      'https://images.unsplash.com/photo-1555949963-aa79dcee981c?w=800&h=400&fit=crop',
-      'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=800&h=400&fit=crop',
-    ],
-    userId: 'user123',
-    createdAt: DateTime.now(),
-    totalVotes: 10,
-    options: [
-      OptionModel(id: '1', text: 'JavaScript', votes: 5, percentage: 50.0),
-      OptionModel(id: '2', text: 'Python', votes: 3, percentage: 30.0),
-      OptionModel(id: '3', text: 'Dart/Flutter', votes: 2, percentage: 20.0),
-    ],
-    userVoted: true,
-    userVoteOption: '1',
-    type: PostType.poll,
-  );
-
-  static PostModel mockPost2 = PostModel(
-    id: '2',
-    title: 'En iyi mobil uygulama geliştirme platformu?',
-    body: 'Mobil uygulama geliştirmek için hangi platform daha avantajlı?',
-    imageUrls: [
-      'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=800&h=400&fit=crop',
-    ],
-    userId: 'user456',
-    createdAt: DateTime.now().subtract(const Duration(days: 1)),
-    totalVotes: 5,
-    options: [
-      OptionModel(id: '1', text: 'Flutter', votes: 2, percentage: 40.0),
-      OptionModel(id: '2', text: 'React Native', votes: 3, percentage: 60.0),
-    ],
-    userVoted: false,
-    userVoteOption: '',
-    type: PostType.poll,
-  );
-
-  static PostModel mockPost3 = PostModel(
-    id: '3',
-    title: 'Favori IDE\'niz hangisi?',
-    body: 'Kod yazarken hangi geliştirme ortamını tercih ediyorsunuz?',
-    userId: 'user789',
-    createdAt: DateTime.now().subtract(const Duration(days: 2)),
-    totalVotes: 0,
-    options: [
-      OptionModel(id: '1', text: 'VS Code', votes: 0, percentage: 50.0),
-      OptionModel(id: '2', text: 'Android Studio', votes: 0, percentage: 50.0),
-    ],
-    userVoted: true,
-    userVoteOption: '2',
-    type: PostType.poll,
-  );
 }

--- a/lib/feature/post/domain/models/quiz_model.dart
+++ b/lib/feature/post/domain/models/quiz_model.dart
@@ -1,0 +1,162 @@
+import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/post/domain/models/quiz_question_model.dart';
+import 'package:prone/feature/post/domain/models/quiz_result_model.dart';
+import 'package:prone/feature/post/domain/models/quiz_scoring_model.dart';
+import 'package:prone/feature/post/presentation/cubits/create_quiz_state.dart';
+
+class QuizModel extends PostModel {
+  final String? description;
+  final List<QuizQuestionModel> questions;
+  final List<QuizResultModel> results;
+  final List<QuizScoringModel> scoring;
+  final bool hasTimeLimit;
+  final DateTime? expiresAt;
+  final int totalParticipants;
+  final bool userParticipated;
+  final String? userResultId;
+
+  const QuizModel({
+    super.id,
+    required super.title,
+    super.body,
+    super.imageUrls,
+    required super.userId,
+    required super.createdAt,
+    super.status,
+    this.description,
+    required this.questions,
+    required this.results,
+    required this.scoring,
+    this.hasTimeLimit = false,
+    this.expiresAt,
+    this.totalParticipants = 0,
+    this.userParticipated = false,
+    this.userResultId,
+  }) : super(type: PostType.quiz);
+
+  factory QuizModel.fromJson(Map<String, dynamic> json) {
+    return QuizModel(
+      id: json['id'] as String?,
+      title: json['title'] as String,
+      body: json['body'] as String?,
+      imageUrls: json['image_urls'] != null
+          ? List<String>.from(json['image_urls'] as List)
+          : null,
+      userId: json['user_id'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      status: PostStatus.values.firstWhere(
+        (e) => e.name == (json['status'] as String? ?? 'draft'),
+        orElse: () => PostStatus.draft,
+      ),
+      description: json['description'] as String?,
+      questions: (json['questions'] as List<dynamic>)
+          .map((q) => QuizQuestionModel.fromJson(q as Map<String, dynamic>))
+          .toList(),
+      results: (json['results'] as List<dynamic>)
+          .map((r) => QuizResultModel.fromJson(r as Map<String, dynamic>))
+          .toList(),
+      scoring: (json['scoring'] as List<dynamic>)
+          .map((s) => QuizScoringModel.fromJson(s as Map<String, dynamic>))
+          .toList(),
+      hasTimeLimit: json['has_time_limit'] as bool? ?? false,
+      expiresAt: json['expires_at'] != null
+          ? DateTime.parse(json['expires_at'] as String)
+          : null,
+      totalParticipants: json['total_participants'] as int? ?? 0,
+      userParticipated: json['user_participated'] as bool? ?? false,
+      userResultId: json['user_result_id'] as String?,
+    );
+  }
+
+  // Factory from CreateQuizState
+  factory QuizModel.fromCreateQuizState(CreateQuizState state, String userId) {
+    return QuizModel(
+      title: state.title,
+      body: state.description,
+      userId: userId,
+      createdAt: DateTime.now(),
+      status: PostStatus.draft,
+      description: state.description,
+      questions: state.questions,
+      results: state.results,
+      scoring: state.scoring,
+      hasTimeLimit: state.hasTimeLimit,
+      expiresAt: state.expiresAt,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toBaseJson() {
+    return {
+      'id': id,
+      'title': title,
+      'body': body,
+      'image_urls': imageUrls,
+      'user_id': userId,
+      'created_at': createdAt.toIso8601String(),
+      'post_type': type.name,
+      'status': status.name,
+      'description': description,
+      'questions': questions.map((q) => q.toJson()).toList(),
+      'results': results.map((r) => r.toJson()).toList(),
+      'scoring': scoring.map((s) => s.toJson()).toList(),
+      'has_time_limit': hasTimeLimit,
+      'expires_at': expiresAt?.toIso8601String(),
+      'total_participants': totalParticipants,
+      'user_participated': userParticipated,
+      'user_result_id': userResultId,
+    };
+  }
+
+  // Helper: Check if quiz is valid for publishing
+  bool get isValidForPublishing {
+    return title.isNotEmpty &&
+        questions.length >= 2 &&
+        results.length >= 2 &&
+        scoring.isNotEmpty;
+  }
+
+  // Helper: Get user's quiz result
+  QuizResultModel? get userResult {
+    if (userResultId == null) return null;
+    return results.where((r) => r.id == userResultId).firstOrNull;
+  }
+
+  QuizModel copyWith({
+    String? id,
+    String? title,
+    String? body,
+    List<String>? imageUrls,
+    String? userId,
+    DateTime? createdAt,
+    PostStatus? status,
+    String? description,
+    List<QuizQuestionModel>? questions,
+    List<QuizResultModel>? results,
+    List<QuizScoringModel>? scoring,
+    bool? hasTimeLimit,
+    DateTime? expiresAt,
+    int? totalParticipants,
+    bool? userParticipated,
+    String? userResultId,
+  }) {
+    return QuizModel(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      body: body ?? this.body,
+      imageUrls: imageUrls ?? this.imageUrls,
+      userId: userId ?? this.userId,
+      createdAt: createdAt ?? this.createdAt,
+      status: status ?? this.status,
+      description: description ?? this.description,
+      questions: questions ?? this.questions,
+      results: results ?? this.results,
+      scoring: scoring ?? this.scoring,
+      hasTimeLimit: hasTimeLimit ?? this.hasTimeLimit,
+      expiresAt: expiresAt ?? this.expiresAt,
+      totalParticipants: totalParticipants ?? this.totalParticipants,
+      userParticipated: userParticipated ?? this.userParticipated,
+      userResultId: userResultId ?? this.userResultId,
+    );
+  }
+}

--- a/lib/feature/post/domain/models/quiz_question_model.dart
+++ b/lib/feature/post/domain/models/quiz_question_model.dart
@@ -1,23 +1,37 @@
-class QuizQuestion {
-  String questionText;
-  List<String> options;
-  int? correctAnswerIndex;
+class QuizQuestionModel {
+  final String id;
+  final String questionText;
+  final List<String> options; // Option IDs
 
-  QuizQuestion({
-    this.questionText = '',
-    List<String>? options,
-    this.correctAnswerIndex,
-  }) : options = options ?? [''];
+  const QuizQuestionModel({
+    required this.id,
+    required this.questionText,
+    required this.options,
+  });
 
-  QuizQuestion copyWith({
+  QuizQuestionModel copyWith({
+    String? id,
     String? questionText,
     List<String>? options,
-    int? correctAnswerIndex,
   }) {
-    return QuizQuestion(
+    return QuizQuestionModel(
+      id: id ?? this.id,
       questionText: questionText ?? this.questionText,
       options: options ?? this.options,
-      correctAnswerIndex: correctAnswerIndex ?? this.correctAnswerIndex,
+    );
+  }
+
+  // ✅ toJson metodu
+  Map<String, dynamic> toJson() {
+    return {'id': id, 'questionText': questionText, 'options': options};
+  }
+
+  // ✅ fromJson metodu
+  factory QuizQuestionModel.fromJson(Map<String, dynamic> json) {
+    return QuizQuestionModel(
+      id: json['id'] as String,
+      questionText: json['questionText'] as String,
+      options: List<String>.from(json['options'] as List),
     );
   }
 }

--- a/lib/feature/post/domain/models/quiz_result_model.dart
+++ b/lib/feature/post/domain/models/quiz_result_model.dart
@@ -3,12 +3,14 @@ class QuizResultModel {
   final String title;
   final String description;
   final String icon;
+  final String colorValue;
 
   const QuizResultModel({
     required this.id,
     required this.title,
     required this.description,
     required this.icon,
+    required this.colorValue,
   });
 
   QuizResultModel copyWith({
@@ -23,6 +25,29 @@ class QuizResultModel {
       title: title ?? this.title,
       description: description ?? this.description,
       icon: icon ?? this.icon,
+      colorValue: colorValue ?? this.colorValue,
+    );
+  }
+
+  // ✅ toJson metodu
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'description': description,
+      'icon': icon,
+      'colorValue': colorValue,
+    };
+  }
+
+  // ✅ fromJson metodu
+  factory QuizResultModel.fromJson(Map<String, dynamic> json) {
+    return QuizResultModel(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      icon: json['icon'] as String,
+      colorValue: json['colorValue'] as String,
     );
   }
 }

--- a/lib/feature/post/domain/models/quiz_scoring_model.dart
+++ b/lib/feature/post/domain/models/quiz_scoring_model.dart
@@ -1,0 +1,66 @@
+class QuizScoringModel {
+  final String questionId;
+  final String optionId;
+  final Map<String, int> resultPoints; // resultId -> points
+
+  const QuizScoringModel({
+    required this.questionId,
+    required this.optionId,
+    required this.resultPoints,
+  });
+
+  QuizScoringModel copyWith({
+    String? questionId,
+    String? optionId,
+    Map<String, int>? resultPoints,
+  }) {
+    return QuizScoringModel(
+      questionId: questionId ?? this.questionId,
+      optionId: optionId ?? this.optionId,
+      resultPoints: resultPoints ?? Map.from(this.resultPoints),
+    );
+  }
+
+  // Helper: Get points for specific result
+  int getPointsForResult(String resultId) {
+    return resultPoints[resultId] ?? 0;
+  }
+
+  // Helper: Set points for specific result
+  QuizScoringModel setPointsForResult(String resultId, int points) {
+    final updatedPoints = Map<String, int>.from(resultPoints);
+    updatedPoints[resultId] = points;
+    return copyWith(resultPoints: updatedPoints);
+  }
+
+  // ✅ toJson metodu
+  Map<String, dynamic> toJson() {
+    return {
+      'questionId': questionId,
+      'optionId': optionId,
+      'resultPoints': resultPoints,
+    };
+  }
+
+  // ✅ fromJson metodu
+  factory QuizScoringModel.fromJson(Map<String, dynamic> json) {
+    return QuizScoringModel(
+      questionId: json['questionId'] as String,
+      optionId: json['optionId'] as String,
+      resultPoints: Map<String, int>.from(json['resultPoints'] as Map),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is QuizScoringModel &&
+        other.questionId == questionId &&
+        other.optionId == optionId;
+  }
+
+  @override
+  int get hashCode {
+    return questionId.hashCode ^ optionId.hashCode;
+  }
+}

--- a/lib/feature/post/domain/repos/post_repo.dart
+++ b/lib/feature/post/domain/repos/post_repo.dart
@@ -1,9 +1,9 @@
 import 'package:prone/feature/post/domain/models/create_poll_model.dart';
-import 'package:prone/feature/post/domain/models/post_model.dart';
+import 'package:prone/feature/post/domain/models/poll_model.dart';
 
 abstract class PostRepo {
   // Method to create a post
-  Future<PostModel> createPoll({required CreatePollModel post});
+  Future<PollModel> createPoll({required CreatePollModel post});
 
   // Method to fetch all posts
   Future<List<Map<String, dynamic>>> fetchPosts();

--- a/lib/feature/post/presentation/cubits/create_quiz_cubit.dart
+++ b/lib/feature/post/presentation/cubits/create_quiz_cubit.dart
@@ -5,7 +5,19 @@ import 'package:prone/feature/post/domain/models/quiz_result_model.dart';
 import 'create_quiz_state.dart';
 
 class CreateQuizCubit extends Cubit<CreateQuizState> {
-  CreateQuizCubit() : super(CreateQuizState(questions: [QuizQuestion()]));
+  // ✅ Constructor'ı düzelt
+  CreateQuizCubit()
+    : super(
+        CreateQuizState(
+          questions: [
+            QuizQuestionModel(
+              id: DateTime.now().millisecondsSinceEpoch.toString(), // ✅ ID ekle
+              questionText: '',
+              options: ['', ''], // ✅ En az 2 boş seçenek
+            ),
+          ],
+        ),
+      );
 
   // --- Event Metotları (UI'dan çağrılacak) ---
 
@@ -34,22 +46,29 @@ class CreateQuizCubit extends Cubit<CreateQuizState> {
   }
 
   // Soru yönetimi
+  // ✅ addQuestion method'unu düzelt
   void addQuestion() {
-    final updatedQuestions = List<QuizQuestion>.from(state.questions)
-      ..add(QuizQuestion());
+    final updatedQuestions = List<QuizQuestionModel>.from(state.questions)
+      ..add(
+        QuizQuestionModel(
+          id: DateTime.now().millisecondsSinceEpoch.toString(), // ✅ ID ekle
+          questionText: '',
+          options: ['', ''], // ✅ En az 2 boş seçenek
+        ),
+      );
     emit(state.copyWith(questions: updatedQuestions));
   }
 
   void removeQuestion(int index) {
     if (state.questions.length > 1) {
-      final updatedQuestions = List<QuizQuestion>.from(state.questions)
+      final updatedQuestions = List<QuizQuestionModel>.from(state.questions)
         ..removeAt(index);
       emit(state.copyWith(questions: updatedQuestions));
     }
   }
 
   void updateQuestionText(int index, String text) {
-    final updatedQuestions = List<QuizQuestion>.from(state.questions);
+    final updatedQuestions = List<QuizQuestionModel>.from(state.questions);
     updatedQuestions[index] = updatedQuestions[index].copyWith(
       questionText: text,
     );
@@ -57,7 +76,7 @@ class CreateQuizCubit extends Cubit<CreateQuizState> {
   }
 
   void addOption(int questionIndex) {
-    final updatedQuestions = List<QuizQuestion>.from(state.questions);
+    final updatedQuestions = List<QuizQuestionModel>.from(state.questions);
     final options = List<String>.from(updatedQuestions[questionIndex].options)
       ..add('');
     updatedQuestions[questionIndex] = updatedQuestions[questionIndex].copyWith(
@@ -67,7 +86,7 @@ class CreateQuizCubit extends Cubit<CreateQuizState> {
   }
 
   void removeOption(int questionIndex, int optionIndex) {
-    final updatedQuestions = List<QuizQuestion>.from(state.questions);
+    final updatedQuestions = List<QuizQuestionModel>.from(state.questions);
     final options = List<String>.from(updatedQuestions[questionIndex].options);
     if (options.length > 1) {
       options.removeAt(optionIndex);
@@ -78,7 +97,7 @@ class CreateQuizCubit extends Cubit<CreateQuizState> {
   }
 
   void updateOption(int questionIndex, int optionIndex, String value) {
-    final updatedQuestions = List<QuizQuestion>.from(state.questions);
+    final updatedQuestions = List<QuizQuestionModel>.from(state.questions);
     final options = List<String>.from(updatedQuestions[questionIndex].options);
     options[optionIndex] = value;
     updatedQuestions[questionIndex] = updatedQuestions[questionIndex].copyWith(
@@ -285,6 +304,7 @@ class CreateQuizCubit extends Cubit<CreateQuizState> {
       title: template['title'] ?? '',
       description: template['description'] ?? '',
       icon: template['icon'] ?? 'emoji_events',
+      colorValue: template['colorValue'] ?? '#FFFFFF', // Default color
     );
     addResult(result);
   }

--- a/lib/feature/post/presentation/cubits/create_quiz_state.dart
+++ b/lib/feature/post/presentation/cubits/create_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:prone/feature/post/domain/models/quiz_question_model.dart';
 import 'package:prone/feature/post/domain/models/quiz_result_model.dart';
+import 'package:prone/feature/post/domain/models/quiz_scoring_model.dart';
 
 enum FormStatus {
   initial,
@@ -19,9 +20,10 @@ class CreateQuizState {
   final DateTime? expiresAt;
 
   final List<QuizResultModel> results;
+  final List<QuizScoringModel> scoring;
 
   // Adım 2: Sorular
-  final List<QuizQuestion> questions;
+  final List<QuizQuestionModel> questions;
 
   // Genel Durum
   final FormStatus status;
@@ -39,6 +41,7 @@ class CreateQuizState {
     this.errorMessage,
     this.validationErrors = const {},
     this.results = const [],
+    this.scoring = const [],
   });
 
   CreateQuizState copyWith({
@@ -47,11 +50,12 @@ class CreateQuizState {
     String? description,
     bool? hasTimeLimit,
     DateTime? expiresAt,
-    List<QuizQuestion>? questions,
+    List<QuizQuestionModel>? questions,
     FormStatus? status,
     String? errorMessage,
     Map<String, String>? validationErrors,
     List<QuizResultModel>? results,
+    List<QuizScoringModel>? scoring,
   }) {
     return CreateQuizState(
       step: step ?? this.step,
@@ -64,6 +68,7 @@ class CreateQuizState {
       errorMessage: errorMessage ?? this.errorMessage,
       validationErrors: validationErrors ?? this.validationErrors,
       results: results ?? this.results,
+      scoring: scoring ?? this.scoring,
     );
   }
 }

--- a/lib/feature/post/presentation/widgets/quiz_options_list.dart
+++ b/lib/feature/post/presentation/widgets/quiz_options_list.dart
@@ -5,7 +5,7 @@ import 'package:prone/feature/post/presentation/cubits/create_quiz_cubit.dart';
 import 'package:prone/feature/post/presentation/widgets/quiz_option_item.dart';
 
 class QuizOptionsList extends StatelessWidget {
-  final QuizQuestion question;
+  final QuizQuestionModel question;
   final int questionIndex;
   final VoidCallback onOptionsChanged;
 
@@ -49,7 +49,7 @@ class QuizOptionsList extends StatelessWidget {
               onOptionsChanged();
             },
           );
-        }).toList(),
+        }),
 
         // Add option button
         TextButton.icon(

--- a/lib/feature/post/presentation/widgets/quiz_question_card.dart
+++ b/lib/feature/post/presentation/widgets/quiz_question_card.dart
@@ -5,7 +5,7 @@ import 'package:prone/feature/post/presentation/widgets/quiz_question_text_input
 import 'package:prone/feature/post/presentation/widgets/quiz_options_list.dart';
 
 class QuizQuestionCard extends StatelessWidget {
-  final QuizQuestion question;
+  final QuizQuestionModel question;
   final int questionNumber;
   final VoidCallback? onRemove;
   final Function(String) onQuestionChanged;

--- a/lib/feature/post/presentation/widgets/quiz_question_text_input.dart
+++ b/lib/feature/post/presentation/widgets/quiz_question_text_input.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:prone/core/utils/quiz_validator.dart';
 
 class QuizQuestionTextInput extends StatelessWidget {
   final Function(String) onChanged;
@@ -15,18 +16,12 @@ class QuizQuestionTextInput extends StatelessWidget {
     return TextFormField(
       initialValue: initialValue,
       decoration: const InputDecoration(
-        labelText: 'Soru metni',
         border: OutlineInputBorder(),
         hintText: 'Sorunuzu buraya yazın...',
       ),
       maxLines: 2,
       onChanged: onChanged,
-      validator: (value) {
-        if (value == null || value.isEmpty) {
-          return 'Soru metni boş olamaz';
-        }
-        return null;
-      },
+      validator: QuizValidator.validateQuizTitle,
     );
   }
 }

--- a/lib/feature/post/presentation/widgets/quiz_steps/create_quiz_basic_info_page.dart
+++ b/lib/feature/post/presentation/widgets/quiz_steps/create_quiz_basic_info_page.dart
@@ -29,6 +29,7 @@ class _CreateQuizBasicInfoScreenState extends State<CreateQuizBasicInfoScreen> {
   void dispose() {
     _titleController.dispose();
     _descriptionController.dispose();
+    formKey.currentState?.dispose();
     super.dispose();
   }
 

--- a/lib/feature/post/presentation/widgets/quiz_steps/create_quiz_results_page.dart
+++ b/lib/feature/post/presentation/widgets/quiz_steps/create_quiz_results_page.dart
@@ -43,6 +43,7 @@ class _CreateQuizResultsPageState extends State<CreateQuizResultsPage> {
       title: '',
       description: '',
       icon: _availableIcons[rnd.nextInt(_availableIcons.length)],
+      colorValue: '#FFFFFF', // Default color
     );
 
     context.read<CreateQuizCubit>().addResult(result);


### PR DESCRIPTION
- Replaced PostCard with PollCard in HomeScreen to display polls.
- Updated PollOption and PollSection to use PollModel instead of PostModel.
- Modified PostFooter to handle different post types (polls and quizzes).
- Removed PostCard as it is no longer needed.
- Adjusted SupabasePostRepo to create and return PollModel instead of PostModel.
- Refactored PostModel to be an abstract class, introducing PollModel and QuizModel.
- Implemented QuizQuestionModel and QuizResultModel with necessary methods.
- Enhanced CreateQuizCubit to manage quiz creation and state.
- Updated quiz-related widgets to use QuizQuestionModel.
- Added QuizScoringModel for scoring logic in quizzes.
- Introduced color handling in quiz results and options.
- Added JSON serialization methods for new models.